### PR TITLE
Add instructions for fixing quarantine issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Download the [Alfred workflow](https://github.com/vegardinho/alfred_bluetooth_co
 Set environment variable `confirm` in workflow to `true` if you want to force user confirmation on toggle and deactivation commands. (Useful for iMacs and Mac Minis who that would have trouble turning Bluetooth on again without any input devices.)
 
 _All the listed commands have their own Remote Trigger._
+
+## Troubleshooting
+
+If you get errors when using the workflow referring to not being able to use `blueutil` as it cannot be checked, you will need to manually remove the quarantine attribute from the bundled binary.
+This can be done like so: `xattr -d com.apple.quarantine /Users/User Name/Library/Application\ Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.*/blueutil`
+(Substitute User Name with your OSX username).


### PR DESCRIPTION
I upgraded to the latest workflow version by following the install instructions, and I then got an issue as my OSX is set to not allow any unsigned apps (company policy etc). I got it to work by manually removing the quarantine flag for the `blueutil` binary, and thought this might be useful for others to know too?
Personally I think I preferred the non-bundled way, but I understand that this is easier on you so :) 