### PR TITLE
Mac M1 toggle problem 

### DIFF
--- a/scripts/connect.osa
+++ b/scripts/connect.osa
@@ -2,7 +2,7 @@
 
 set connected to do shell script "echo $(./blueutil --is-connected \"$uid\")"
 if connected is equal to "1" then
-	do shell script "./blueutil --disconnect \"$uid\""
+	do shell script "./blueutil --disconnect \"$uid\" --info \"$uid\""
 	return -1
 end if
 


### PR DESCRIPTION
adding --info to the connect script seems to fix the toggle issue on m1 macs
no new binary should be required for this as it is working for me on m1 macbook air

here is the disconnect/ connect hotkey workflow
![image](https://user-images.githubusercontent.com/5321192/139754378-21ab1c60-ced4-4453-97ba-a7ea71a38c71.png)
