### PR TITLE
Update to python3 as MacOS12.3 removes 2.x

### DIFF
--- a/scripts/get_display_name.py
+++ b/scripts/get_display_name.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-from __future__ import print_function, absolute_import
 from subprocess import check_output
 import json
 import sys
@@ -9,7 +8,7 @@ from return_device_json import get_display_name
 
 
 def main():
-	dev_id = sys.argv[1].decode("utf-8")
+	dev_id = sys.argv[1]
 	dev_name = get_display_name(dev_id)
 	if not dev_name:
 		dev_info = check_output(["./blueutil", "--format", "json", "--info", dev_id])

--- a/scripts/get_favorite.py
+++ b/scripts/get_favorite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # encoding: utf-8
 
 import subprocess
@@ -10,7 +10,8 @@ def main():
     stdout.write(get_fav_dev())
 
 def get_fav_dev():
-    return subprocess.check_output(CMD, shell=True)
+    fav_dev = subprocess.check_output(CMD, shell=True)
+    return fav_dev.decode()
 
 if __name__ == '__main__':
     main()

--- a/scripts/return_device_json.py
+++ b/scripts/return_device_json.py
@@ -1,7 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # encoding: utf-8
-
-from __future__ import print_function, absolute_import
 
 import json
 import os
@@ -21,9 +19,9 @@ def main():
 
     """Run script."""
     # Script command
-    subtitle = sys.argv[1].decode("utf-8")
+    subtitle = sys.argv[1]
     # User search query
-    query = sys.argv[2].decode("utf-8") if len(sys.argv) > 2 else None
+    query = sys.argv[2] if len(sys.argv) > 2 else None
 
     # Ensure cache directory exists
     if not os.path.exists(CACHE_DIR):
@@ -32,7 +30,8 @@ def main():
 
     if not query:  # Get devices from blueutil
         cmd_args = get_args(subtitle)
-        js = check_output(cmd_args)
+        js_bytes = check_output(cmd_args)
+        js = js_bytes.decode()
         with open(DEVICES_PATH, "w") as fp:
             fp.write(js)
         devices = json.loads(js)
@@ -46,7 +45,7 @@ def main():
     for device in devices:
         device_name = device["name"]
         if device_name is None:
-            continue        
+            continue
 
         # Check if custom name
         display_name = get_display_name(device["address"])


### PR DESCRIPTION
Apple removed Python2 from MacOS Monterey 12.3
This commit makes the bluetooth workflow work in 12.3
No backwards compatibility checked, so might break on older OS